### PR TITLE
feat: user-owned short URLs, auth middleware, /me endpoint, bearer auth docs

### DIFF
--- a/src/application/errors/unauthorized.error.ts
+++ b/src/application/errors/unauthorized.error.ts
@@ -1,0 +1,12 @@
+import { BaseError, ErrorKinds } from '@shared/errors.js'
+
+/**
+ * Error thrown when authentication is required but missing or invalid.
+ * @augments {BaseError}
+ */
+export class UnauthorizedError extends BaseError {
+  constructor(message = 'Unauthorized') {
+    super(ErrorKinds.auth, 'UNAUTHORIZED', message)
+    this.name = 'UnauthorizedError'
+  }
+}

--- a/src/application/use-cases/shorten-url.use-case.ts
+++ b/src/application/use-cases/shorten-url.use-case.ts
@@ -26,14 +26,15 @@ export class ShortenUrl {
   /**
    * Attempts to generate and store a unique short code for the given URL, retrying on collisions.
    * @param {string} originalUrl - The full URL to shorten. Must be a valid URL string.
+   * @param {string | undefined} userId - Optional owner user id. When provided, the short url will be associated with this user.
    * @returns {Promise<string>} A promise that resolves to the full shortened URL (including base URL and code).
    * @throws {MaxCodeGenerationAttemptsError} Thrown if a unique code could not be generated within the configured maximum attempts.
    * @throws {Error} Re-throws any unexpected errors from the storage client (other than code-collision errors).
    */
-  async shortenUrl(originalUrl: string): Promise<string> {
+  async shortenUrl(originalUrl: string, userId?: string): Promise<string> {
     for (let attempt = 1; attempt <= this.maxAttempts; attempt++) {
       const code = this.nanoid()
-      const candidate = new ShortUrl('', code, new ValidUrl(originalUrl))
+      const candidate = new ShortUrl('', code, new ValidUrl(originalUrl), userId)
 
       try {
         await this.repo.save(candidate)

--- a/src/domain/entities/short-url.ts
+++ b/src/domain/entities/short-url.ts
@@ -18,10 +18,20 @@ export class ShortUrl extends BaseEntity {
     return this.originalUrl.value
   }
 
+  /**
+   * Identifier of the owning user, if this short url is user-owned.
+   * Anonymous short urls will have this value undefined.
+   * @returns {string | undefined} the user id or undefined
+   */
+  public get userId(): string | undefined {
+    return this._userId
+  }
+
   constructor(
     public readonly id: string,
     public readonly code: string,
     private originalUrl: ValidUrl,
+    private readonly _userId?: string,
     isNew: boolean = true,
   ) {
     if (!code) {

--- a/src/infrastructure/db/migrations/postgres/0005-add-user-id-to-short-urls.ts
+++ b/src/infrastructure/db/migrations/postgres/0005-add-user-id-to-short-urls.ts
@@ -19,7 +19,7 @@ class AddUserIdToShortUrlsMigration extends Migration<PgClient> {
   async up(): Promise<void> {
     await this.ctx.query(`
      ALTER TABLE app.short_urls
-      ADD COLUMN AFTER original_url IF NOT EXISTS user_id uuid NULL;
+      ADD COLUMN IF NOT EXISTS user_id uuid NULL;
     `)
 
     // Create index if not exists

--- a/src/infrastructure/db/migrations/postgres/0005-add-user-id-to-short-urls.ts
+++ b/src/infrastructure/db/migrations/postgres/0005-add-user-id-to-short-urls.ts
@@ -1,0 +1,59 @@
+import { PgClient } from '@infrastructure/clients/pg-client.js'
+import { Migration } from '@infrastructure/db/migrations/types.js'
+
+/**
+ * Adds nullable user_id column to app.short_urls to support owned short urls.
+ * Column: user_id uuid null references app.users(id) on delete set null (assuming users table exists)
+ * Also adds an index on user_id for faster lookup of user-owned urls.
+ */
+class AddUserIdToShortUrlsMigration extends Migration<PgClient> {
+  public constructor(ctx: PgClient, id: string) {
+    super(ctx, id)
+  }
+
+  /**
+   * Executes the migration to add user_id column and index if they do not already exist.
+   * Uses conditional logic to avoid errors on repeated runs.
+   * @returns {Promise<void>}
+   */
+  async up(): Promise<void> {
+    await this.ctx.query(`
+     ALTER TABLE app.short_urls
+      ADD COLUMN AFTER original_url IF NOT EXISTS user_id uuid NULL;
+    `)
+
+    // Create index if not exists
+    await this.ctx.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1
+          FROM pg_constraint
+          WHERE conname  = 'fk_short_urls__user'
+            AND conrelid = 'app.short_urls'::regclass
+        ) THEN
+          ALTER TABLE app.short_urls
+            ADD CONSTRAINT fk_short_urls__user
+            FOREIGN KEY (user_id)
+            REFERENCES app."users"(id)
+            ON DELETE CASCADE;
+        END IF;
+      END$$;
+    `)
+
+    await this.ctx.query(`
+      CREATE INDEX IF NOT EXISTS idx_short_urls_user_id
+        ON app.short_urls(user_id);
+    `)
+  }
+}
+
+/**
+ * Factory for the migration adding user_id to short_urls.
+ * @param {PgClient} client Postgres client
+ * @param {string} id migration id
+ * @returns {AddUserIdToShortUrlsMigration} migration instance
+ */
+export default function createAddUserIdToShortUrlsMigration(client: PgClient, id: string) {
+  return new AddUserIdToShortUrlsMigration(client, id)
+}

--- a/src/infrastructure/repositories/url/mongo-short-url.repository.ts
+++ b/src/infrastructure/repositories/url/mongo-short-url.repository.ts
@@ -9,6 +9,7 @@ export type MongoShortUrl = {
   _id?: ObjectId
   code: string
   originalUrl: string
+  userId?: string
   createdAt: Date
   updatedAt: Date
   schemaVersion: Int32
@@ -44,6 +45,7 @@ export class MongoShortUrlRepository implements IShortUrlRepository {
       result._id!.toString(),
       result.code,
       new ValidUrl(result.originalUrl),
+      result.userId,
       false,
     )
   }
@@ -63,6 +65,7 @@ export class MongoShortUrlRepository implements IShortUrlRepository {
     const code = {
       code: entity.code,
       originalUrl: entity.url,
+      userId: entity.userId,
       createdAt: new Date(),
       updatedAt: new Date(),
       schemaVersion: this.version,

--- a/src/infrastructure/repositories/url/mongo-short-url.repository.unit.test.ts
+++ b/src/infrastructure/repositories/url/mongo-short-url.repository.unit.test.ts
@@ -36,6 +36,7 @@ describe('MongoShortUrlRepository', () => {
         _id: new ObjectId('66a6f8a0c0d5f0a1a1a1a1a1'),
         code: 'abc123',
         originalUrl: 'https://example.com',
+        userId: 'user-1',
         createdAt: new Date(),
         updatedAt: new Date(),
         schemaVersion: new Int32(1),
@@ -62,7 +63,7 @@ describe('MongoShortUrlRepository', () => {
 
   describe('save()', () => {
     it('inserts a new ShortUrl document when not persisted', async () => {
-      const entity = new ShortUrl('', 'abc123', new ValidUrl('https://ex.com'))
+      const entity = new ShortUrl('', 'abc123', new ValidUrl('https://ex.com'), 'user-42')
       collection.insertOne.mockResolvedValue({
         acknowledged: true,
         insertedId: new ObjectId(),
@@ -74,6 +75,7 @@ describe('MongoShortUrlRepository', () => {
       const arg = collection.insertOne.mock.calls[0][0] as MongoShortUrl
       expect(arg.code).toBe('abc123')
       expect(arg.originalUrl).toBe('https://ex.com')
+      expect(arg.userId).toBe('user-42')
       expect(arg.schemaVersion).toBeInstanceOf(Int32)
       expect(arg.schemaVersion.valueOf()).toBe(1)
     })
@@ -91,7 +93,13 @@ describe('MongoShortUrlRepository', () => {
     })
 
     it('throws ImmutableCodeError when trying to save an already-persisted entity', async () => {
-      const entity = new ShortUrl('some-id', 'abc123', new ValidUrl('https://ex.com'), false)
+      const entity = new ShortUrl(
+        'some-id',
+        'abc123',
+        new ValidUrl('https://ex.com'),
+        undefined,
+        false,
+      )
 
       await expect(repo.save(entity)).rejects.toBeInstanceOf(ImmutableCodeError)
       expect(collection.insertOne).not.toHaveBeenCalled()

--- a/src/infrastructure/repositories/url/postgres-short-url.repository.unit.test.ts
+++ b/src/infrastructure/repositories/url/postgres-short-url.repository.unit.test.ts
@@ -25,6 +25,7 @@ describe('PostgresShortUrlRepository', () => {
         id: '11111111-1111-1111-1111-111111111111',
         code: 'abc123',
         original_url: 'https://example.com',
+        user_id: 'user-77',
         created_at: new Date(),
         updated_at: new Date(),
       }
@@ -34,12 +35,13 @@ describe('PostgresShortUrlRepository', () => {
       const result = await repo.findByCode('abc123')
 
       expect(pg.findOne).toHaveBeenCalledWith(
-        'select id, code, original_url from app.short_urls where code = $1',
+        'select id, code, original_url, user_id from app.short_urls where code = $1',
         ['abc123'],
       )
       expect(result).toBeInstanceOf(ShortUrl)
       expect(result?.code).toBe('abc123')
       expect(result?.url).toBe('https://example.com')
+      expect(result?.userId).toBe('user-77')
     })
 
     it('returns null when no row is found', async () => {
@@ -48,7 +50,7 @@ describe('PostgresShortUrlRepository', () => {
       const result = await repo.findByCode('missing')
 
       expect(pg.findOne).toHaveBeenCalledWith(
-        'select id, code, original_url from app.short_urls where code = $1',
+        'select id, code, original_url, user_id from app.short_urls where code = $1',
         ['missing'],
       )
       expect(result).toBeNull()
@@ -56,15 +58,27 @@ describe('PostgresShortUrlRepository', () => {
   })
 
   describe('save()', () => {
-    it('inserts a new row for a non-persisted entity', async () => {
+    it('inserts a new row for a non-persisted entity (anonymous)', async () => {
       pg.insertOrThrow.mockResolvedValue(undefined)
       const entity = new ShortUrl('', 'abc123', new ValidUrl('https://ex.com'))
 
       await expect(repo.save(entity)).resolves.toBeUndefined()
 
       expect(pg.insertOrThrow).toHaveBeenCalledWith(
-        'insert into app.short_urls (code, original_url, created_at, updated_at) values ($1, $2, now(), now())',
-        ['abc123', 'https://ex.com'],
+        'insert into app.short_urls (code, original_url, user_id, created_at, updated_at) values ($1, $2, $3, now(), now())',
+        ['abc123', 'https://ex.com', null],
+      )
+    })
+
+    it('inserts a new row with user_id for a user-owned short url', async () => {
+      pg.insertOrThrow.mockResolvedValue(undefined)
+      const entity = new ShortUrl('', 'abc999', new ValidUrl('https://ex2.com'), 'user-22')
+
+      await expect(repo.save(entity)).resolves.toBeUndefined()
+
+      expect(pg.insertOrThrow).toHaveBeenCalledWith(
+        'insert into app.short_urls (code, original_url, user_id, created_at, updated_at) values ($1, $2, $3, now(), now())',
+        ['abc999', 'https://ex2.com', 'user-22'],
       )
     })
 
@@ -80,6 +94,7 @@ describe('PostgresShortUrlRepository', () => {
         '11111111-1111-1111-1111-111111111111',
         'abc123',
         new ValidUrl('https://ex.com'),
+        undefined,
         false,
       )
 

--- a/src/infrastructure/repositories/url/redis-short-url.repository.ts
+++ b/src/infrastructure/repositories/url/redis-short-url.repository.ts
@@ -26,7 +26,7 @@ export class RedisShortUrlRepository implements IShortUrlRepository {
     const url = await this.client.get(code)
     if (!url) return null
     // Move to factory when more persistent objects are added
-    return new ShortUrl(code, code, new ValidUrl(url), false)
+    return new ShortUrl(code, code, new ValidUrl(url), undefined, false)
   }
 
   /**

--- a/src/presentation/controllers/shortener.controller.ts
+++ b/src/presentation/controllers/shortener.controller.ts
@@ -21,7 +21,7 @@ export class ShortenerController {
    */
   public async shorten(req: Request, res: Response) {
     const { url } = req.body
-    res.status(201).send({ shortUrl: await this.shortenUrlUC.shortenUrl(url) })
+    res.status(201).send({ shortUrl: await this.shortenUrlUC.shortenUrl(url, req.userId) })
   }
 
   /**

--- a/src/presentation/docs/swagger.ts
+++ b/src/presentation/docs/swagger.ts
@@ -45,6 +45,17 @@ export const swaggerSpec = swaggerJSDoc({
           },
         },
       },
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+          description:
+            'Supply the access token in the Authorization header as: Bearer <token>'.concat(
+              config.isDev ? '\nIssued tokens are short-lived; refresh via auth endpoints.' : '',
+            ),
+        },
+      },
       responses: {
         SystemError: {
           description: 'System Error',

--- a/src/presentation/middlewares/error-handler.middleware.ts
+++ b/src/presentation/middlewares/error-handler.middleware.ts
@@ -47,6 +47,8 @@ export function errorHandler(err: Error, req: Request, res: Response, next: Next
  */
 function mapStatus(e: BaseError): number {
   switch (e.kind) {
+    case ErrorKinds.auth:
+      return 401
     case ErrorKinds.validation:
       return 422
     case ErrorKinds.conflict:

--- a/src/presentation/middlewares/require-auth.middleware.ts
+++ b/src/presentation/middlewares/require-auth.middleware.ts
@@ -1,0 +1,35 @@
+import { NextFunction, Request, Response, RequestHandler } from 'express'
+
+import { IJwtVerifier } from '@application/ports/jwt-verifier.js'
+import { UnauthorizedError } from '@application/errors/unauthorized.error.js'
+
+declare module 'express' {
+  interface Request {
+    userId?: string
+  }
+}
+
+/**
+ * Middleware enforcing that a valid Bearer token is provided.
+ * Extracts the user id (subject) from the JWT and attaches it to req.userId.
+ * Responds 401 on missing/invalid token.
+ * @param {IJwtVerifier} verifier JWT verifier service.
+ * @returns {RequestHandler} Express middleware.
+ */
+export function requireAuth(verifier: IJwtVerifier): RequestHandler {
+  return async (req: Request, _res: Response, next: NextFunction) => {
+    const unauthorized = () => next(new UnauthorizedError())
+    try {
+      const header = req.header('authorization') || req.header('Authorization')
+      if (!header || !header.toLowerCase().startsWith('bearer ')) return unauthorized()
+      const token = header.slice(7).trim()
+      if (!token) return unauthorized()
+      const verified = await verifier.verify(token)
+      if (!verified) return unauthorized()
+      req.userId = verified.subject
+      return next()
+    } catch {
+      return unauthorized()
+    }
+  }
+}

--- a/src/presentation/routes/auth.routes.ts
+++ b/src/presentation/routes/auth.routes.ts
@@ -11,7 +11,7 @@ import { withUnitOfWork } from '@presentation/utils/with-unit-of-work.js'
  * @returns {Router} Express Router with user routes registered.
  */
 export function createAuthRouter(controller: AuthController, uow: IUnitOfWork): Router {
-  const userRouter = Router()
+  const authRouter = Router()
 
   /**
    * @openapi
@@ -65,7 +65,7 @@ export function createAuthRouter(controller: AuthController, uow: IUnitOfWork): 
    *       '500':
    *         $ref: '#/components/responses/SystemError'
    */
-  userRouter.post('/auth/register', controller.register.bind(controller))
+  authRouter.post('/auth/register', controller.register.bind(controller))
 
   /**
    * @openapi
@@ -126,7 +126,7 @@ export function createAuthRouter(controller: AuthController, uow: IUnitOfWork): 
    *       '500':
    *         $ref: '#/components/responses/SystemError'
    */
-  userRouter.post('/auth/login', withUnitOfWork(uow, controller.login.bind(controller)))
+  authRouter.post('/auth/login', withUnitOfWork(uow, controller.login.bind(controller)))
 
-  return userRouter
+  return authRouter
 }

--- a/src/presentation/routes/me.routes.ts
+++ b/src/presentation/routes/me.routes.ts
@@ -1,0 +1,51 @@
+import { Router } from 'express'
+
+import { ShortenerController } from '@presentation/controllers/shortener.controller.js'
+import { requireAuth } from '@presentation/middlewares/require-auth.middleware.js'
+import { IJwtVerifier } from '@application/ports/jwt-verifier.js'
+
+/**
+ * Creates a router for authenticated user ("me") operations.
+ * @param {ShortenerController} controller - The shortener controller handling logic.
+ * @param {IJwtVerifier} verifier - JWT verifier used to authenticate requests.
+ * @returns {Router} - The configured router for /me endpoints.
+ */
+export function createMeRouter(controller: ShortenerController, verifier: IJwtVerifier): Router {
+  const meRouter = Router()
+
+  /**
+   * @openapi
+   * /me/shorten:
+   *  post:
+   *    summary: Create a new short URL owned by the authenticated user
+   *    security:
+   *      - bearerAuth: []
+   *    requestBody:
+   *      required: true
+   *      content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               url:
+   *                 type: string
+   *    responses:
+   *      '201':
+   *        description: The shortened URL
+   *        content:
+   *          'application/json':
+   *            schema:
+   *              $ref: '#/components/schemas/ErrorFormat'
+   *      '401':
+   *        description: Unauthorized
+   *        content:
+   *          'application/json':
+   *            schema:
+   *              $ref: '#/components/schemas/ErrorFormat'
+   *      '500':
+   *        $ref: '#/components/responses/SystemError'
+   */
+  meRouter.post('/me/shorten', requireAuth(verifier), (req, res) => controller.shorten(req, res))
+
+  return meRouter
+}

--- a/src/presentation/routes/redirect.routes.ts
+++ b/src/presentation/routes/redirect.routes.ts
@@ -41,6 +41,8 @@ export function createRedirectRoutes(shortenerController: ShortenerController): 
    *           'application/json':
    *             schema:
    *               $ref: '#/components/schemas/ErrorFormat'
+   *       '500':
+   *         $ref: '#/components/responses/SystemError'
    */
   redirectRouter.get('/:code', shortenerController.resolve.bind(shortenerController))
 

--- a/src/presentation/routes/shortener.routes.ts
+++ b/src/presentation/routes/shortener.routes.ts
@@ -5,7 +5,7 @@ import { ShortenerController } from '@presentation/controllers/shortener.control
 /**
  * Creates a router for URL shortening operations.
  * @param {ShortenerController} controller - The controller to handle URL shortening logic.
- * @returns {Router} - The configured router for URL shortening.
+ * @returns {Router} - The configured router for public URL shortening.
  */
 export function createShortenerRouter(controller: ShortenerController): Router {
   const shortenerRouter = Router()
@@ -44,6 +44,8 @@ export function createShortenerRouter(controller: ShortenerController): Router {
    *          application/json:
    *            schema:
    *              $ref: '#/components/schemas/ErrorFormat'
+   *      '500':
+   *        $ref: '#/components/responses/SystemError'
    */
   shortenerRouter.post('/shorten', controller.shorten.bind(controller))
 

--- a/src/presentation/server.ts
+++ b/src/presentation/server.ts
@@ -6,6 +6,7 @@ import { createShortenerRouter } from '@presentation/routes/shortener.routes.js'
 import { createV1Router } from '@presentation/routes/v1.routes.js'
 import { createRedirectRoutes } from '@presentation/routes/redirect.routes.js'
 import { createAuthRouter } from '@presentation/routes/auth.routes.js'
+import { createMeRouter } from '@presentation/routes/me.routes.js'
 import { AuthController } from '@presentation/controllers/auth.controller.js'
 import { ShortenUrl } from '@application/use-cases/shorten-url.use-case.js'
 import { ResolveUrl } from '@application/use-cases/resolve-url.use-case.js'
@@ -106,6 +107,7 @@ async function bootstrap() {
 
   const apiRouter = createV1Router(
     createShortenerRouter(shortenerController),
+    createMeRouter(shortenerController, jwtService),
     createAuthRouter(authController, uow),
   )
 


### PR DESCRIPTION
### Summary
Adds authenticated, user-owned URL shortening plus supporting infrastructure and documentation refinements.

### Key Changes
- Domain: `ShortUrl` entity extended with optional `userId`.
- Persistence: Repositories updated to read/write `user_id`; new migration `0005-add-user-id-to-short-urls` (nullable FK-ready column).
- Application: `ShortenUrl` use case now accepts optional `userId` (single unified path for owned + anonymous URLs).
- Added `requireAuth` middleware to handle request authentication.
- Routes: Added dedicated `me` router with `POST /me/shorten` (protected) and slimmed original shortener router to public endpoints only.
- OpenAPI: Defined `bearerAuth` security scheme; documented `/me/shorten` with security + error responses.
- Controller: `ShortenerController` now uses `req.userId` for owned link generation.